### PR TITLE
Change public variable to private to keep the classes safe

### DIFF
--- a/projects/SmallTheftAuto/Assets/Scripts/CarMovement.cs
+++ b/projects/SmallTheftAuto/Assets/Scripts/CarMovement.cs
@@ -4,12 +4,20 @@ using UnityEngine;
 
 public class CarMovement : MonoBehaviour {
 
+    /*
+     * Instead of public variables, I rather keep it private but serializable.
+     * E.g: [SerializeField] private float driftFactor.
+     *
+     * the tag [SerializeField] allows the variable to be showed in the inspector
+     * but the private state doesn't let other classes to access it.
+     */
+    
     [Header("Car Settings")]
-    public float driftFactor = 0.95f;
-    public float accelerationFactor = 30;
-    public float breakForce = 100f;
-    public float turnFactor = 3.5f;
-    public float maxSpeed = 20;
+    [SerializeField] private float driftFactor = 0.95f;
+    [SerializeField] private float accelerationFactor = 30;
+    [SerializeField] private float breakForce = 100f;
+    [SerializeField] private float turnFactor = 3.5f;
+    [SerializeField] private float maxSpeed = 20;
 
     private float accelerationInput = 0;
     private float steeringInput = 0;

--- a/projects/SmallTheftAuto/Assets/Scripts/PlayerMovement.cs
+++ b/projects/SmallTheftAuto/Assets/Scripts/PlayerMovement.cs
@@ -1,18 +1,29 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(Rigidbody2D))]
 public class PlayerMovement : MonoBehaviour
 {
-
-    public float moveSpeed = 5f;
-
-    public Rigidbody2D rb;
-    public Camera cam;
+    [SerializeField] private float moveSpeed = 5f;
+    [SerializeField] private Camera cam;
+    
+    private Rigidbody2D rb;
 
     Vector2 movement;
     Vector2 mousePos;
-    
+
+    private void Awake()
+    {
+        /*
+         * If something doens't need to be changed by designer, it is better to assign it through code.
+         * So we don't have a risk to loose the reference.
+         * There is a tag ovre the class delaration that forces the game object to have a RigidBody2D
+         */
+        rb = GetComponent<Rigidbody2D>();
+    }
+
     void Update()
     {
         movement.x = Input.GetAxisRaw("Horizontal");
@@ -24,9 +35,13 @@ public class PlayerMovement : MonoBehaviour
     private void FixedUpdate()
     {
         rb.MovePosition(rb.position + movement * moveSpeed * Time.fixedDeltaTime);
+        LookAtMouse(); // It is easier to know what's happening inside here :)
+    }
 
+    private void LookAtMouse()
+    {
         Vector3 lookDir = mousePos - rb.position;
-        float angle = Mathf.Atan2(lookDir.y ,lookDir.x) * Mathf.Rad2Deg - 90f;
+        float angle = Mathf.Atan2(lookDir.y, lookDir.x) * Mathf.Rad2Deg - 90f;
         rb.rotation = angle;
     }
 }

--- a/projects/SmallTheftAuto/Assets/Scripts/PlayerMovement.cs
+++ b/projects/SmallTheftAuto/Assets/Scripts/PlayerMovement.cs
@@ -17,9 +17,9 @@ public class PlayerMovement : MonoBehaviour
     private void Awake()
     {
         /*
-         * If something doens't need to be changed by designer, it is better to assign it through code.
+         * If something doesn't need to be changed in the editor, it is better to assign it through code.
          * So we don't have a risk to loose the reference.
-         * There is a tag ovre the class delaration that forces the game object to have a RigidBody2D
+         * There is a tag over the class declaration that forces this game object to have a RigidBody2D
          */
         rb = GetComponent<Rigidbody2D>();
     }


### PR DESCRIPTION
First of all, great work everyone!

Keep it private is the best way to prevent other classes to change data unintentionally. My approach to this is to keep everything private and add a tag [SerializeField] if I want someone to change the variables through the Unity's inspector.

If you want a properties to be accessed by other methods it is better to do something like that:

```cs
public int Health {get; set;}
```
So we can track who is accessing and changing it.

Hope it helps :)
 